### PR TITLE
Better global gitignore for Golang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -219,8 +219,10 @@ rel/example_project
 *.out
 
 ### Go Patch ###
-/vendor/
-/Godeps/
+*.prof
+*.pprof
+**/go/vendor/
+**/go/Godeps/
 
 
 ### Haskell ###


### PR DESCRIPTION
Adds output from profiling tools and allows vendor and dependency directories to be nested inside a "go" folder.

Reasoning to add `.prof`: https://golang.org/pkg/runtime/pprof/
Reasoning to add `.pprof`: https://golang.org/cmd/trace/

I also changed the vendor and godep directories so they can be inside any folder named "go". This assumes everyone will follow the convention of putting go code inside a folder a go folder.

The `.prof` extension is already in Haskell, but i think it's better to have it duplicated in case the Haskell part of gitignore changes in the future.

 